### PR TITLE
feat: support global parameters

### DIFF
--- a/packages/orq-rc/src/hooks/global.ts
+++ b/packages/orq-rc/src/hooks/global.ts
@@ -19,10 +19,10 @@ import {
         const payload = await request.json()
   
         if ('context' in payload && typeof payload.context === 'object') {
-          payload.context.environment = environment;
+          payload.context.environments = environment;
         } else {
           payload.context = {
-            environment
+            environments: environment
           }
         }
         return new Request(request.url, {

--- a/packages/orq-rc/src/hooks/global.ts
+++ b/packages/orq-rc/src/hooks/global.ts
@@ -1,0 +1,38 @@
+import {
+    BeforeRequestHook,
+    BeforeRequestContext
+  } from "./types";
+  
+  export class GlobalHook implements BeforeRequestHook {
+    async beforeRequest(hookCtx: BeforeRequestContext, request: Request): Promise<Request> {
+      const contactId = request.headers.get('contactId')
+      if (contactId) {
+        request.headers.set('x-orq-contact-id', contactId);
+        request.headers.delete('contactId')
+      }
+  
+      const environment = request.headers.get('environment')
+      
+      // if the operation is related to deployment invoke & invoke stream
+      if (["DeploymentInvoke", "DeploymentStream"].includes(hookCtx.operationID) && environment) {
+        request.headers.delete('environment')
+        const payload = await request.json()
+  
+        if ('context' in payload && typeof payload.context === 'object') {
+          payload.context.environment = environment;
+        } else {
+          payload.context = {
+            environment
+          }
+        }
+        return new Request(request.url, {
+          method: request.method,
+          headers: request.headers,
+          body: JSON.stringify(payload),
+          signal: request.signal
+        });
+      }
+  
+      return request;
+    }
+  }

--- a/packages/orq-rc/src/hooks/registration.ts
+++ b/packages/orq-rc/src/hooks/registration.ts
@@ -1,3 +1,4 @@
+import { GlobalHook } from "./global.js";
 import { Hooks } from "./types.js";
 
 /*
@@ -6,9 +7,9 @@ import { Hooks } from "./types.js";
  * in this file or in separate files in the hooks folder.
  */
 
-// @ts-expect-error remove this line when you add your first hook and hooks is used
 export function initHooks(hooks: Hooks) {
   // Add hooks by calling hooks.register{ClientInit/BeforeCreateRequest/BeforeRequest/AfterSuccess/AfterError}Hook
   // with an instance of a hook that implements that specific Hook interface
   // Hooks are registered per SDK instance, and are valid for the lifetime of the SDK instance
+  hooks.registerBeforeRequestHook(new GlobalHook());
 }

--- a/src/hooks/global.ts
+++ b/src/hooks/global.ts
@@ -19,10 +19,10 @@ import {
         const payload = await request.json()
   
         if ('context' in payload && typeof payload.context === 'object') {
-          payload.context.environment = environment;
+          payload.context.environments = environment;
         } else {
           payload.context = {
-            environment
+            environments: environment
           }
         }
         return new Request(request.url, {

--- a/src/hooks/global.ts
+++ b/src/hooks/global.ts
@@ -1,0 +1,38 @@
+import {
+    BeforeRequestHook,
+    BeforeRequestContext
+  } from "./types";
+  
+  export class GlobalHook implements BeforeRequestHook {
+    async beforeRequest(hookCtx: BeforeRequestContext, request: Request): Promise<Request> {
+      const contactId = request.headers.get('contactId')
+      if (contactId) {
+        request.headers.set('x-orq-contact-id', contactId);
+        request.headers.delete('contactId')
+      }
+  
+      const environment = request.headers.get('environment')
+      
+      // if the operation is related to deployment invoke & invoke stream
+      if (["DeploymentInvoke", "DeploymentStream"].includes(hookCtx.operationID) && environment) {
+        request.headers.delete('environment')
+        const payload = await request.json()
+  
+        if ('context' in payload && typeof payload.context === 'object') {
+          payload.context.environment = environment;
+        } else {
+          payload.context = {
+            environment
+          }
+        }
+        return new Request(request.url, {
+          method: request.method,
+          headers: request.headers,
+          body: JSON.stringify(payload),
+          signal: request.signal
+        });
+      }
+  
+      return request;
+    }
+  }

--- a/src/hooks/registration.ts
+++ b/src/hooks/registration.ts
@@ -1,3 +1,4 @@
+import { GlobalHook } from "./global.js";
 import { Hooks } from "./types.js";
 
 /*
@@ -6,9 +7,9 @@ import { Hooks } from "./types.js";
  * in this file or in separate files in the hooks folder.
  */
 
-// @ts-expect-error remove this line when you add your first hook and hooks is used
 export function initHooks(hooks: Hooks) {
   // Add hooks by calling hooks.register{ClientInit/BeforeCreateRequest/BeforeRequest/AfterSuccess/AfterError}Hook
   // with an instance of a hook that implements that specific Hook interface
   // Hooks are registered per SDK instance, and are valid for the lifetime of the SDK instance
+  hooks.registerBeforeRequestHook(new GlobalHook());
 }


### PR DESCRIPTION
support adding contact_id to every point as header
support setting context environment on deployment invoke and stream

the hooks in speakeasy does not have direct access to global parameters, to access this we have to add the global parameters as state in here https://www.speakeasy.com/docs/customize/globals and we have to update every endpoint to reference the global parameter so it gets injected in hooks via the header (sample below is the name of the global parameter contactId which then get processed by the hook rename it to x-orq-contact-id then delete the contactId in header which was set by speakeasy) for adding global parameter and injecting the global parameter to be reference on every point is on the orquesta-web repo PR

![2025-01-30_08-33_1](https://github.com/user-attachments/assets/c90c4bff-d8a1-4934-a001-fa9f0914a6bc)
![2025-01-30_08-33](https://github.com/user-attachments/assets/9342880f-d057-4de5-b7f8-4d0130435c26)
