### PR TITLE
Disable MCP server generation to fix build OOM error

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -43,7 +43,7 @@ typescript:
   constFieldsAlwaysOptional: false
   defaultErrorName: APIError
   enableCustomCodeRegions: false
-  enableMCPServer: true
+  enableMCPServer: false
   enableReactQuery: false
   enumFormat: union
   envVarPrefix: ORQ

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "@orq-ai/node",
   "version": "4.1.14",
   "author": "Orq",
-  "bin": {
-    "mcp": "bin/mcp-server.js"
-  },
   "main": "./index.js",
   "sideEffects": false,
   "repository": {
@@ -13,8 +10,7 @@
   },
   "scripts": {
     "lint": "eslint --cache --max-warnings=0 src",
-    "build:mcp": "bun src/mcp-server/build.mts",
-    "build": "npm run build:mcp && tsc",
+    "build": "tsc",
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {

--- a/packages/orq-rc/.speakeasy/gen.yaml
+++ b/packages/orq-rc/.speakeasy/gen.yaml
@@ -42,7 +42,7 @@ typescript:
   constFieldsAlwaysOptional: false
   defaultErrorName: APIError
   enableCustomCodeRegions: false
-  enableMCPServer: true
+  enableMCPServer: false
   enableReactQuery: false
   enumFormat: union
   envVarPrefix: ORQ

--- a/packages/orq-rc/package.json
+++ b/packages/orq-rc/package.json
@@ -2,9 +2,6 @@
   "name": "@orq-ai/node",
   "version": "4.2.0-rc.58",
   "author": "Orq",
-  "bin": {
-    "mcp": "bin/mcp-server.js"
-  },
   "main": "./index.js",
   "sideEffects": false,
   "repository": {
@@ -14,8 +11,7 @@
   },
   "scripts": {
     "lint": "eslint --cache --max-warnings=0 src",
-    "build:mcp": "bun src/mcp-server/build.mts",
-    "build": "npm run build:mcp && tsc",
+    "build": "tsc",
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {


### PR DESCRIPTION
The MCP server build was causing JavaScript heap out of memory errors due to bundling 100+ tool files that import the entire SDK (5.5MB of models). Since MCP is not being used, disable it in both packages.