### PR TITLE
fix(langchain): preserve tool_calls on LLM-end output (TOPS-1894)

### DIFF
--- a/packages/orq-rc/src/langchain/async-handler.mts
+++ b/packages/orq-rc/src/langchain/async-handler.mts
@@ -15,6 +15,7 @@ import { Events } from "./events.mjs";
 import { EventType, InFlightEvent, createInFlightEvent } from "./models.mjs";
 import { buildOtlpSpan } from "./span-builder.mjs";
 import {
+  extractAssistantToolCalls,
   extractModelName,
   extractModelParameters,
   extractTokenUsage,
@@ -192,9 +193,20 @@ export class AsyncOrqLangchainCallback extends BaseCallbackHandler {
               content = event.streamingTokens.join("");
             }
 
+            const message: Record<string, unknown> = {
+              role: "assistant",
+              content,
+            };
+            const toolCalls = extractAssistantToolCalls(
+              (gen as unknown as Record<string, unknown>)["message"],
+            );
+            if (toolCalls) {
+              message["tool_calls"] = toolCalls;
+            }
+
             choices.push({
               index: idx,
-              message: { role: "assistant", content },
+              message,
               finish_reason: finishReason,
             });
           }

--- a/packages/orq-rc/src/langchain/handler.mts
+++ b/packages/orq-rc/src/langchain/handler.mts
@@ -15,6 +15,7 @@ import { Events } from "./events.mjs";
 import { EventType, InFlightEvent, createInFlightEvent } from "./models.mjs";
 import { buildOtlpSpan } from "./span-builder.mjs";
 import {
+  extractAssistantToolCalls,
   extractModelName,
   extractModelParameters,
   extractTokenUsage,
@@ -192,9 +193,20 @@ export class OrqLangchainCallback extends BaseCallbackHandler {
               content = event.streamingTokens.join("");
             }
 
+            const message: Record<string, unknown> = {
+              role: "assistant",
+              content,
+            };
+            const toolCalls = extractAssistantToolCalls(
+              (gen as unknown as Record<string, unknown>)["message"],
+            );
+            if (toolCalls) {
+              message["tool_calls"] = toolCalls;
+            }
+
             choices.push({
               index: idx,
-              message: { role: "assistant", content },
+              message,
               finish_reason: finishReason,
             });
           }

--- a/packages/orq-rc/src/langchain/utils.mts
+++ b/packages/orq-rc/src/langchain/utils.mts
@@ -117,6 +117,30 @@ export function normalizeMessages(
   return result;
 }
 
+export function extractAssistantToolCalls(
+  message: unknown,
+): unknown[] | null {
+  if (message == null || typeof message !== "object") return null;
+  const msg = message as Record<string, unknown>;
+
+  const additionalKwargs = msg["additional_kwargs"];
+  if (additionalKwargs != null && typeof additionalKwargs === "object") {
+    const fromKwargs = (additionalKwargs as Record<string, unknown>)[
+      "tool_calls"
+    ];
+    if (Array.isArray(fromKwargs) && fromKwargs.length > 0) {
+      return fromKwargs;
+    }
+  }
+
+  const fromMessage = msg["tool_calls"];
+  if (Array.isArray(fromMessage) && fromMessage.length > 0) {
+    return fromMessage;
+  }
+
+  return null;
+}
+
 function readUsage(
   usage: Record<string, unknown> | undefined,
 ): Record<string, number> | null {

--- a/src/langchain/async-handler.mts
+++ b/src/langchain/async-handler.mts
@@ -15,6 +15,7 @@ import { Events } from "./events.mjs";
 import { EventType, InFlightEvent, createInFlightEvent } from "./models.mjs";
 import { buildOtlpSpan } from "./span-builder.mjs";
 import {
+  extractAssistantToolCalls,
   extractModelName,
   extractModelParameters,
   extractTokenUsage,
@@ -192,9 +193,20 @@ export class AsyncOrqLangchainCallback extends BaseCallbackHandler {
               content = event.streamingTokens.join("");
             }
 
+            const message: Record<string, unknown> = {
+              role: "assistant",
+              content,
+            };
+            const toolCalls = extractAssistantToolCalls(
+              (gen as unknown as Record<string, unknown>)["message"],
+            );
+            if (toolCalls) {
+              message["tool_calls"] = toolCalls;
+            }
+
             choices.push({
               index: idx,
-              message: { role: "assistant", content },
+              message,
               finish_reason: finishReason,
             });
           }

--- a/src/langchain/handler.mts
+++ b/src/langchain/handler.mts
@@ -15,6 +15,7 @@ import { Events } from "./events.mjs";
 import { EventType, InFlightEvent, createInFlightEvent } from "./models.mjs";
 import { buildOtlpSpan } from "./span-builder.mjs";
 import {
+  extractAssistantToolCalls,
   extractModelName,
   extractModelParameters,
   extractTokenUsage,
@@ -192,9 +193,20 @@ export class OrqLangchainCallback extends BaseCallbackHandler {
               content = event.streamingTokens.join("");
             }
 
+            const message: Record<string, unknown> = {
+              role: "assistant",
+              content,
+            };
+            const toolCalls = extractAssistantToolCalls(
+              (gen as unknown as Record<string, unknown>)["message"],
+            );
+            if (toolCalls) {
+              message["tool_calls"] = toolCalls;
+            }
+
             choices.push({
               index: idx,
-              message: { role: "assistant", content },
+              message,
               finish_reason: finishReason,
             });
           }

--- a/src/langchain/utils.mts
+++ b/src/langchain/utils.mts
@@ -117,6 +117,30 @@ export function normalizeMessages(
   return result;
 }
 
+export function extractAssistantToolCalls(
+  message: unknown,
+): unknown[] | null {
+  if (message == null || typeof message !== "object") return null;
+  const msg = message as Record<string, unknown>;
+
+  const additionalKwargs = msg["additional_kwargs"];
+  if (additionalKwargs != null && typeof additionalKwargs === "object") {
+    const fromKwargs = (additionalKwargs as Record<string, unknown>)[
+      "tool_calls"
+    ];
+    if (Array.isArray(fromKwargs) && fromKwargs.length > 0) {
+      return fromKwargs;
+    }
+  }
+
+  const fromMessage = msg["tool_calls"];
+  if (Array.isArray(fromMessage) && fromMessage.length > 0) {
+    return fromMessage;
+  }
+
+  return null;
+}
+
 function readUsage(
   usage: Record<string, unknown> | undefined,
 ): Record<string, number> | null {


### PR DESCRIPTION
handleLLMEnd previously built choices[].message from gen.text only, dropping tool_calls when the model finished with finish_reason=tool_calls. Read them from gen.message.additional_kwargs.tool_calls (OpenAI shape) or gen.message.tool_calls (LangChain shape) and include on the message.

Mirrored across the sync and async callbacks in both src/langchain/ and packages/orq-rc/src/langchain/.