### PR TITLE
fix(langchain): normalize chain span roles and trim root span output (ENG-1785)

### DIFF
--- a/packages/orq-rc/src/langchain/async-handler.mts
+++ b/packages/orq-rc/src/langchain/async-handler.mts
@@ -15,6 +15,7 @@ import { Events } from "./events.mjs";
 import { EventType, InFlightEvent, createInFlightEvent } from "./models.mjs";
 import { buildOtlpSpan } from "./span-builder.mjs";
 import {
+  coerceChainPayload,
   extractAssistantToolCalls,
   extractModelName,
   extractModelParameters,
@@ -24,6 +25,7 @@ import {
   nanoTimestamp,
   normalizeMessages,
   resolveSpanName,
+  rootOutputDelta,
   stringifyToolOutput,
 } from "./utils.mjs";
 
@@ -79,6 +81,7 @@ export class AsyncOrqLangchainCallback extends BaseCallbackHandler {
     const span = buildOtlpSpan(event);
     await this._client.sendSpan(span);
     this._events.remove(runId);
+    this._events.clearRoot(runId);
   }
 
   // ── LLM callbacks ──────────────────────────────────────────────
@@ -263,10 +266,7 @@ export class AsyncOrqLangchainCallback extends BaseCallbackHandler {
         tags,
         runName,
       );
-      event.inputs =
-        typeof inputs === "object" && inputs !== null && !Array.isArray(inputs)
-          ? inputs
-          : { inputs };
+      event.inputs = coerceChainPayload(inputs);
 
       if (parentRunId == null) {
         this._events.setRootIfNeeded(runId);
@@ -290,12 +290,11 @@ export class AsyncOrqLangchainCallback extends BaseCallbackHandler {
       const event = this._events.get(runId);
       if (!event) return;
       event.endTimeNs = nanoTimestamp();
-      event.outputs =
-        typeof outputs === "object" &&
-        outputs !== null &&
-        !Array.isArray(outputs)
-          ? outputs
-          : { outputs };
+      let outputsDict = coerceChainPayload(outputs);
+      if (this._events.isRoot(runId)) {
+        outputsDict = rootOutputDelta(event.inputs, outputsDict);
+      }
+      event.outputs = outputsDict;
 
       if (this._events.isGraphNode(runId)) {
         this._events.graph.onNodeEnd(event.name, this._events.rootRunId!);

--- a/packages/orq-rc/src/langchain/events.mts
+++ b/packages/orq-rc/src/langchain/events.mts
@@ -11,7 +11,7 @@ export class Events {
   private _events = new Map<string, InFlightEvent>();
   private _parentMap = new Map<string, string | undefined>();
   private _rootRunId: string | null = null;
-  readonly graph = new GraphTracker();
+  graph = new GraphTracker();
 
   store(runId: string, event: InFlightEvent): void {
     this._events.set(runId, event);
@@ -44,6 +44,19 @@ export class Events {
 
   isRoot(runId: string): boolean {
     return runId === this._rootRunId;
+  }
+
+  /**
+   * Clear root tracking when the current root chain finishes.
+   * Allows subsequent top-level invocations on the same handler to
+   * be correctly identified as roots, and resets graph state so node
+   * tracking from the previous run doesn't leak into the next.
+   */
+  clearRoot(runId: string): void {
+    if (runId === this._rootRunId) {
+      this._rootRunId = null;
+      this.graph = new GraphTracker();
+    }
   }
 
   isGraphNode(runId: string): boolean {

--- a/packages/orq-rc/src/langchain/handler.mts
+++ b/packages/orq-rc/src/langchain/handler.mts
@@ -15,6 +15,7 @@ import { Events } from "./events.mjs";
 import { EventType, InFlightEvent, createInFlightEvent } from "./models.mjs";
 import { buildOtlpSpan } from "./span-builder.mjs";
 import {
+  coerceChainPayload,
   extractAssistantToolCalls,
   extractModelName,
   extractModelParameters,
@@ -24,6 +25,7 @@ import {
   nanoTimestamp,
   normalizeMessages,
   resolveSpanName,
+  rootOutputDelta,
   stringifyToolOutput,
 } from "./utils.mjs";
 
@@ -79,6 +81,7 @@ export class OrqLangchainCallback extends BaseCallbackHandler {
     const span = buildOtlpSpan(event);
     this._client.sendSpan(span);
     this._events.remove(runId);
+    this._events.clearRoot(runId);
   }
 
   // ── LLM callbacks ──────────────────────────────────────────────
@@ -263,10 +266,7 @@ export class OrqLangchainCallback extends BaseCallbackHandler {
         tags,
         runName,
       );
-      event.inputs =
-        typeof inputs === "object" && inputs !== null && !Array.isArray(inputs)
-          ? inputs
-          : { inputs };
+      event.inputs = coerceChainPayload(inputs);
 
       if (parentRunId == null) {
         this._events.setRootIfNeeded(runId);
@@ -290,12 +290,11 @@ export class OrqLangchainCallback extends BaseCallbackHandler {
       const event = this._events.get(runId);
       if (!event) return;
       event.endTimeNs = nanoTimestamp();
-      event.outputs =
-        typeof outputs === "object" &&
-        outputs !== null &&
-        !Array.isArray(outputs)
-          ? outputs
-          : { outputs };
+      let outputsDict = coerceChainPayload(outputs);
+      if (this._events.isRoot(runId)) {
+        outputsDict = rootOutputDelta(event.inputs, outputsDict);
+      }
+      event.outputs = outputsDict;
 
       if (this._events.isGraphNode(runId)) {
         this._events.graph.onNodeEnd(event.name, this._events.rootRunId!);

--- a/packages/orq-rc/src/langchain/span-builder.mts
+++ b/packages/orq-rc/src/langchain/span-builder.mts
@@ -8,7 +8,7 @@
  */
 
 import { EventType, InFlightEvent } from "./models.mjs";
-import { nanoTimestamp } from "./utils.mjs";
+import { maybeNormalizeChainMessages, nanoTimestamp } from "./utils.mjs";
 
 // ── OTLP attribute encoding ──────────────────────────────────────
 
@@ -290,7 +290,7 @@ function buildPrompt(event: InFlightEvent): unknown {
     event.eventType === EventType.CHAIN ||
     event.eventType === EventType.AGENT
   ) {
-    return event.inputs;
+    return maybeNormalizeChainMessages(event.inputs);
   }
   if (event.eventType === EventType.TOOL) {
     if (event.toolInput != null) return { input: event.toolInput };
@@ -312,7 +312,7 @@ function buildCompletion(event: InFlightEvent): unknown {
     event.eventType === EventType.CHAIN ||
     event.eventType === EventType.AGENT
   ) {
-    return event.outputs;
+    return maybeNormalizeChainMessages(event.outputs);
   }
   if (event.eventType === EventType.TOOL) {
     if (event.toolOutput != null) return { output: event.toolOutput };

--- a/packages/orq-rc/src/langchain/utils.mts
+++ b/packages/orq-rc/src/langchain/utils.mts
@@ -117,6 +117,137 @@ export function normalizeMessages(
   return result;
 }
 
+function isBaseMessage(value: unknown): value is BaseMessage {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    typeof (value as { _getType?: unknown })._getType === "function"
+  );
+}
+
+function normalizeChainMessageItem(item: unknown): unknown {
+  if (isBaseMessage(item)) {
+    return normalizeMessages([[item]])[0];
+  }
+  if (
+    Array.isArray(item) &&
+    item.length === 2 &&
+    typeof item[0] === "string"
+  ) {
+    const aliases: Record<string, string> = { human: "user", ai: "assistant" };
+    const raw = (item[0] as string).toLowerCase();
+    return { role: aliases[raw] ?? raw, content: item[1] };
+  }
+  return item;
+}
+
+function isNormalizableArray(value: unknown): value is unknown[] {
+  if (!Array.isArray(value) || value.length === 0) return false;
+  return value.some(
+    (m) =>
+      isBaseMessage(m) ||
+      (Array.isArray(m) && m.length === 2 && typeof m[0] === "string"),
+  );
+}
+
+/**
+ * Normalize a chain payload's message arrays to role-typed dicts.
+ *
+ * Handles raw BaseMessage objects (from LangGraph state) and
+ * `[role, content]` tuples (the form accepted by agent.invoke). Scans every
+ * top-level key — common variants are `messages`, `output`, `outputs`,
+ * `input`, `inputs` — so prompt template / RunnableSequence outputs render
+ * with structured roles instead of the lc-serialized blob.
+ */
+export function maybeNormalizeChainMessages(payload: unknown): unknown {
+  if (payload == null || typeof payload !== "object" || Array.isArray(payload)) {
+    return payload;
+  }
+  const obj = payload as Record<string, unknown>;
+  let changed = false;
+  const next: Record<string, unknown> = { ...obj };
+  for (const [key, value] of Object.entries(obj)) {
+    if (isNormalizableArray(value)) {
+      next[key] = (value as unknown[]).map(normalizeChainMessageItem);
+      changed = true;
+    } else if (isBaseMessage(value)) {
+      next[key] = normalizeChainMessageItem(value);
+      changed = true;
+    }
+  }
+  return changed ? next : payload;
+}
+
+/**
+ * Wrap chain inputs/outputs into a dict suitable for the span normalizer.
+ *
+ * LangChain hands callbacks raw BaseMessage objects (or lists thereof) for
+ * chains like RunnableSequence wrapping a chat model. Without coercion they
+ * get stored as `{outputs: <AIMessage>}` and serialized via the default
+ * stringifier, producing an unreadable repr in the trace. Wrapping them as
+ * `{messages: [...]}` routes through the normal role/tool_calls path.
+ */
+export function coerceChainPayload(payload: unknown): Record<string, unknown> {
+  // Check BaseMessage first — a BaseMessage IS an object, so the plain-dict
+  // branch below would otherwise swallow it and ship the raw lc-serialized
+  // form (via toJSON) instead of normalized {role, content, tool_calls}.
+  if (isBaseMessage(payload)) {
+    return { messages: [payload] };
+  }
+  if (Array.isArray(payload) && payload.length > 0 && payload.every(isBaseMessage)) {
+    return { messages: payload };
+  }
+  if (payload != null && typeof payload === "object" && !Array.isArray(payload)) {
+    return payload as Record<string, unknown>;
+  }
+  return { outputs: payload };
+}
+
+function messageId(msg: unknown): string | undefined {
+  if (msg == null || typeof msg !== "object") return undefined;
+  const m = msg as Record<string, unknown>;
+  const id = m["id"];
+  return typeof id === "string" ? id : undefined;
+}
+
+/**
+ * Return outputs with input messages stripped from outputs.messages.
+ *
+ * LangGraph's root on_chain_end receives the full merged state, so the
+ * input turns reappear in outputs.messages. Use message ids when every
+ * input has one (handles RemoveMessage correctly); otherwise fall back to
+ * positional trimming, which is safe under the append-only add_messages
+ * reducer LangGraph uses by default.
+ */
+export function rootOutputDelta(
+  inputs: Record<string, unknown> | null | undefined,
+  outputs: Record<string, unknown>,
+): Record<string, unknown> {
+  if (inputs == null || typeof inputs !== "object" || Array.isArray(inputs)) {
+    return outputs;
+  }
+  const inMsgs = (inputs as Record<string, unknown>)["messages"];
+  const outMsgs = outputs["messages"];
+  if (!Array.isArray(inMsgs) || !Array.isArray(outMsgs) || outMsgs.length === 0) {
+    return outputs;
+  }
+
+  const inIds = inMsgs.map(messageId);
+  if (inIds.length > 0 && inIds.every((id): id is string => id != null)) {
+    const inputIdSet = new Set<string>(inIds);
+    const delta = outMsgs.filter((m) => {
+      const id = messageId(m);
+      return id == null || !inputIdSet.has(id);
+    });
+    return { ...outputs, messages: delta };
+  }
+
+  if (outMsgs.length >= inMsgs.length) {
+    return { ...outputs, messages: outMsgs.slice(inMsgs.length) };
+  }
+  return outputs;
+}
+
 export function extractAssistantToolCalls(
   message: unknown,
 ): unknown[] | null {

--- a/src/langchain/async-handler.mts
+++ b/src/langchain/async-handler.mts
@@ -15,6 +15,7 @@ import { Events } from "./events.mjs";
 import { EventType, InFlightEvent, createInFlightEvent } from "./models.mjs";
 import { buildOtlpSpan } from "./span-builder.mjs";
 import {
+  coerceChainPayload,
   extractAssistantToolCalls,
   extractModelName,
   extractModelParameters,
@@ -24,6 +25,7 @@ import {
   nanoTimestamp,
   normalizeMessages,
   resolveSpanName,
+  rootOutputDelta,
   stringifyToolOutput,
 } from "./utils.mjs";
 
@@ -79,6 +81,7 @@ export class AsyncOrqLangchainCallback extends BaseCallbackHandler {
     const span = buildOtlpSpan(event);
     await this._client.sendSpan(span);
     this._events.remove(runId);
+    this._events.clearRoot(runId);
   }
 
   // ── LLM callbacks ──────────────────────────────────────────────
@@ -263,10 +266,7 @@ export class AsyncOrqLangchainCallback extends BaseCallbackHandler {
         tags,
         runName,
       );
-      event.inputs =
-        typeof inputs === "object" && inputs !== null && !Array.isArray(inputs)
-          ? inputs
-          : { inputs };
+      event.inputs = coerceChainPayload(inputs);
 
       if (parentRunId == null) {
         this._events.setRootIfNeeded(runId);
@@ -290,12 +290,11 @@ export class AsyncOrqLangchainCallback extends BaseCallbackHandler {
       const event = this._events.get(runId);
       if (!event) return;
       event.endTimeNs = nanoTimestamp();
-      event.outputs =
-        typeof outputs === "object" &&
-        outputs !== null &&
-        !Array.isArray(outputs)
-          ? outputs
-          : { outputs };
+      let outputsDict = coerceChainPayload(outputs);
+      if (this._events.isRoot(runId)) {
+        outputsDict = rootOutputDelta(event.inputs, outputsDict);
+      }
+      event.outputs = outputsDict;
 
       if (this._events.isGraphNode(runId)) {
         this._events.graph.onNodeEnd(event.name, this._events.rootRunId!);

--- a/src/langchain/events.mts
+++ b/src/langchain/events.mts
@@ -11,7 +11,7 @@ export class Events {
   private _events = new Map<string, InFlightEvent>();
   private _parentMap = new Map<string, string | undefined>();
   private _rootRunId: string | null = null;
-  readonly graph = new GraphTracker();
+  graph = new GraphTracker();
 
   store(runId: string, event: InFlightEvent): void {
     this._events.set(runId, event);
@@ -44,6 +44,19 @@ export class Events {
 
   isRoot(runId: string): boolean {
     return runId === this._rootRunId;
+  }
+
+  /**
+   * Clear root tracking when the current root chain finishes.
+   * Allows subsequent top-level invocations on the same handler to
+   * be correctly identified as roots, and resets graph state so node
+   * tracking from the previous run doesn't leak into the next.
+   */
+  clearRoot(runId: string): void {
+    if (runId === this._rootRunId) {
+      this._rootRunId = null;
+      this.graph = new GraphTracker();
+    }
   }
 
   isGraphNode(runId: string): boolean {

--- a/src/langchain/handler.mts
+++ b/src/langchain/handler.mts
@@ -15,6 +15,7 @@ import { Events } from "./events.mjs";
 import { EventType, InFlightEvent, createInFlightEvent } from "./models.mjs";
 import { buildOtlpSpan } from "./span-builder.mjs";
 import {
+  coerceChainPayload,
   extractAssistantToolCalls,
   extractModelName,
   extractModelParameters,
@@ -24,6 +25,7 @@ import {
   nanoTimestamp,
   normalizeMessages,
   resolveSpanName,
+  rootOutputDelta,
   stringifyToolOutput,
 } from "./utils.mjs";
 
@@ -79,6 +81,7 @@ export class OrqLangchainCallback extends BaseCallbackHandler {
     const span = buildOtlpSpan(event);
     this._client.sendSpan(span);
     this._events.remove(runId);
+    this._events.clearRoot(runId);
   }
 
   // ── LLM callbacks ──────────────────────────────────────────────
@@ -263,10 +266,7 @@ export class OrqLangchainCallback extends BaseCallbackHandler {
         tags,
         runName,
       );
-      event.inputs =
-        typeof inputs === "object" && inputs !== null && !Array.isArray(inputs)
-          ? inputs
-          : { inputs };
+      event.inputs = coerceChainPayload(inputs);
 
       if (parentRunId == null) {
         this._events.setRootIfNeeded(runId);
@@ -290,12 +290,11 @@ export class OrqLangchainCallback extends BaseCallbackHandler {
       const event = this._events.get(runId);
       if (!event) return;
       event.endTimeNs = nanoTimestamp();
-      event.outputs =
-        typeof outputs === "object" &&
-        outputs !== null &&
-        !Array.isArray(outputs)
-          ? outputs
-          : { outputs };
+      let outputsDict = coerceChainPayload(outputs);
+      if (this._events.isRoot(runId)) {
+        outputsDict = rootOutputDelta(event.inputs, outputsDict);
+      }
+      event.outputs = outputsDict;
 
       if (this._events.isGraphNode(runId)) {
         this._events.graph.onNodeEnd(event.name, this._events.rootRunId!);

--- a/src/langchain/span-builder.mts
+++ b/src/langchain/span-builder.mts
@@ -8,7 +8,7 @@
  */
 
 import { EventType, InFlightEvent } from "./models.mjs";
-import { nanoTimestamp } from "./utils.mjs";
+import { maybeNormalizeChainMessages, nanoTimestamp } from "./utils.mjs";
 
 // ── OTLP attribute encoding ──────────────────────────────────────
 
@@ -290,7 +290,7 @@ function buildPrompt(event: InFlightEvent): unknown {
     event.eventType === EventType.CHAIN ||
     event.eventType === EventType.AGENT
   ) {
-    return event.inputs;
+    return maybeNormalizeChainMessages(event.inputs);
   }
   if (event.eventType === EventType.TOOL) {
     if (event.toolInput != null) return { input: event.toolInput };
@@ -312,7 +312,7 @@ function buildCompletion(event: InFlightEvent): unknown {
     event.eventType === EventType.CHAIN ||
     event.eventType === EventType.AGENT
   ) {
-    return event.outputs;
+    return maybeNormalizeChainMessages(event.outputs);
   }
   if (event.eventType === EventType.TOOL) {
     if (event.toolOutput != null) return { output: event.toolOutput };

--- a/src/langchain/utils.mts
+++ b/src/langchain/utils.mts
@@ -117,6 +117,137 @@ export function normalizeMessages(
   return result;
 }
 
+function isBaseMessage(value: unknown): value is BaseMessage {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    typeof (value as { _getType?: unknown })._getType === "function"
+  );
+}
+
+function normalizeChainMessageItem(item: unknown): unknown {
+  if (isBaseMessage(item)) {
+    return normalizeMessages([[item]])[0];
+  }
+  if (
+    Array.isArray(item) &&
+    item.length === 2 &&
+    typeof item[0] === "string"
+  ) {
+    const aliases: Record<string, string> = { human: "user", ai: "assistant" };
+    const raw = (item[0] as string).toLowerCase();
+    return { role: aliases[raw] ?? raw, content: item[1] };
+  }
+  return item;
+}
+
+function isNormalizableArray(value: unknown): value is unknown[] {
+  if (!Array.isArray(value) || value.length === 0) return false;
+  return value.some(
+    (m) =>
+      isBaseMessage(m) ||
+      (Array.isArray(m) && m.length === 2 && typeof m[0] === "string"),
+  );
+}
+
+/**
+ * Normalize a chain payload's message arrays to role-typed dicts.
+ *
+ * Handles raw BaseMessage objects (from LangGraph state) and
+ * `[role, content]` tuples (the form accepted by agent.invoke). Scans every
+ * top-level key — common variants are `messages`, `output`, `outputs`,
+ * `input`, `inputs` — so prompt template / RunnableSequence outputs render
+ * with structured roles instead of the lc-serialized blob.
+ */
+export function maybeNormalizeChainMessages(payload: unknown): unknown {
+  if (payload == null || typeof payload !== "object" || Array.isArray(payload)) {
+    return payload;
+  }
+  const obj = payload as Record<string, unknown>;
+  let changed = false;
+  const next: Record<string, unknown> = { ...obj };
+  for (const [key, value] of Object.entries(obj)) {
+    if (isNormalizableArray(value)) {
+      next[key] = (value as unknown[]).map(normalizeChainMessageItem);
+      changed = true;
+    } else if (isBaseMessage(value)) {
+      next[key] = normalizeChainMessageItem(value);
+      changed = true;
+    }
+  }
+  return changed ? next : payload;
+}
+
+/**
+ * Wrap chain inputs/outputs into a dict suitable for the span normalizer.
+ *
+ * LangChain hands callbacks raw BaseMessage objects (or lists thereof) for
+ * chains like RunnableSequence wrapping a chat model. Without coercion they
+ * get stored as `{outputs: <AIMessage>}` and serialized via the default
+ * stringifier, producing an unreadable repr in the trace. Wrapping them as
+ * `{messages: [...]}` routes through the normal role/tool_calls path.
+ */
+export function coerceChainPayload(payload: unknown): Record<string, unknown> {
+  // Check BaseMessage first — a BaseMessage IS an object, so the plain-dict
+  // branch below would otherwise swallow it and ship the raw lc-serialized
+  // form (via toJSON) instead of normalized {role, content, tool_calls}.
+  if (isBaseMessage(payload)) {
+    return { messages: [payload] };
+  }
+  if (Array.isArray(payload) && payload.length > 0 && payload.every(isBaseMessage)) {
+    return { messages: payload };
+  }
+  if (payload != null && typeof payload === "object" && !Array.isArray(payload)) {
+    return payload as Record<string, unknown>;
+  }
+  return { outputs: payload };
+}
+
+function messageId(msg: unknown): string | undefined {
+  if (msg == null || typeof msg !== "object") return undefined;
+  const m = msg as Record<string, unknown>;
+  const id = m["id"];
+  return typeof id === "string" ? id : undefined;
+}
+
+/**
+ * Return outputs with input messages stripped from outputs.messages.
+ *
+ * LangGraph's root on_chain_end receives the full merged state, so the
+ * input turns reappear in outputs.messages. Use message ids when every
+ * input has one (handles RemoveMessage correctly); otherwise fall back to
+ * positional trimming, which is safe under the append-only add_messages
+ * reducer LangGraph uses by default.
+ */
+export function rootOutputDelta(
+  inputs: Record<string, unknown> | null | undefined,
+  outputs: Record<string, unknown>,
+): Record<string, unknown> {
+  if (inputs == null || typeof inputs !== "object" || Array.isArray(inputs)) {
+    return outputs;
+  }
+  const inMsgs = (inputs as Record<string, unknown>)["messages"];
+  const outMsgs = outputs["messages"];
+  if (!Array.isArray(inMsgs) || !Array.isArray(outMsgs) || outMsgs.length === 0) {
+    return outputs;
+  }
+
+  const inIds = inMsgs.map(messageId);
+  if (inIds.length > 0 && inIds.every((id): id is string => id != null)) {
+    const inputIdSet = new Set<string>(inIds);
+    const delta = outMsgs.filter((m) => {
+      const id = messageId(m);
+      return id == null || !inputIdSet.has(id);
+    });
+    return { ...outputs, messages: delta };
+  }
+
+  if (outMsgs.length >= inMsgs.length) {
+    return { ...outputs, messages: outMsgs.slice(inMsgs.length) };
+  }
+  return outputs;
+}
+
 export function extractAssistantToolCalls(
   message: unknown,
 ): unknown[] | null {


### PR DESCRIPTION
Mirrors the orq-python fix for the same set of LangChain/LangGraph trace problems on chain and root trace spans:

- Roles collapsed because chain inputs and outputs were serialized via the LangChain BaseMessage toJSON, producing the lc-serialized blob instead of structured role/content/tool_calls fields.
- The root trace span output echoed the full merged state including the input messages instead of only the delta the run produced.
- Multiple top-level invocations on the same handler only registered the first as root, so subsequent traces did not get root-only processing.
- Bare BaseMessage outputs from RunnableSequence chains (wrapping a chat model) hit the plain-object branch of coerceChainPayload and shipped the raw lc form via JSON.stringify's default toJSON.

This change:

- Adds maybeNormalizeChainMessages which scans every top-level key in a chain payload for arrays of BaseMessages or role/content tuples and normalizes them. Broader than the Python equivalent because LangChain JS surfaces BaseMessages under multiple keys (messages, output, etc.) via extra chain layers (prompt, RunnableSequence, RunnableLambda).
- Adds rootOutputDelta to subtract input messages from the root span's output by message id, with positional trim fallback when ids absent.
- Adds clearRoot on chain finish so subsequent invocations on the same handler each register as their own root.
- Adds coerceChainPayload to wrap bare BaseMessage outputs into a messages list before serialization. BaseMessage check runs before the plain-object check so AIMessages do not slip through as-is.
- Mirrors changes into packages/orq-rc.