### PR TITLE
ci: raise Node heap limit for SDK generation build

### DIFF
--- a/.github/workflows/sdk_generation.yml
+++ b/.github/workflows/sdk_generation.yml
@@ -33,6 +33,8 @@ jobs:
       mode: direct
       target: ${{ inputs.target }}
       force: ${{ inputs.force }}
+      environment: |
+        NODE_OPTIONS=--max-old-space-size=8192
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}


### PR DESCRIPTION
tsc runs out of memory compiling the generated SDK with Node's default heap cap (~6GB), failing the generate step. Pass NODE_OPTIONS through the speakeasy action's `environment` input so it reaches the `npm run build` child process.

Uses `environment` rather than the workflow `env:` block because GitHub does not propagate a caller's env context into a reusable workflow.

Issues

<img width="1468" height="838" alt="2026-08-05_15-25" src="https://github.com/user-attachments/assets/d85cba33-62a2-4b19-92e6-85a26dbf4f23" />
<img width="1901" height="929" alt="2026-08-05_15-24" src="https://github.com/user-attachments/assets/c4e9985d-862c-4847-bc69-4cdc31e26152" />
