### PR TITLE
Ci/tsc heap build script v2

### DIFF
--- a/.github/workflows/sdk_generation.yml
+++ b/.github/workflows/sdk_generation.yml
@@ -33,8 +33,6 @@ jobs:
       mode: direct
       target: ${{ inputs.target }}
       force: ${{ inputs.force }}
-      environment: |
-        NODE_OPTIONS=--max-old-space-size=8192
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -48,7 +48,8 @@ typescript:
         import: ./langchain/index.mjs
         require: ./langchain/index.js
         types: ./langchain/index.d.mts
-  additionalScripts: {}
+  additionalScripts:
+    build: node --max-old-space-size=8192 ./node_modules/typescript/bin/tsc
   alwaysIncludeInboundAndOutbound: false
   apiPromiseHelpers: false
   author: Orq

--- a/packages/orq-rc/.speakeasy/gen.yaml
+++ b/packages/orq-rc/.speakeasy/gen.yaml
@@ -48,7 +48,8 @@ typescript:
         import: ./langchain/index.mjs
         require: ./langchain/index.js
         types: ./langchain/index.d.mts
-  additionalScripts: {}
+  additionalScripts:
+    build: node --max-old-space-size=8192 ./node_modules/typescript/bin/tsc
   alwaysIncludeInboundAndOutbound: false
   apiPromiseHelpers: false
   author: Orq


### PR DESCRIPTION
set Node heap limit via generated build script

NODE_OPTIONS via the action's `environment` input never reached tsc.

Github workflow is picking up the env pass but its not getting passed unfortunately down to tsc process which issue is still happening.

<img width="1524" height="972" alt="2026-08-05_17-19_1" src="https://github.com/user-attachments/assets/57af89b9-ec75-4871-afce-4e10b78e7e57" />
<img width="1517" height="950" alt="2026-08-05_17-19" src="https://github.com/user-attachments/assets/a2eb9b82-e70d-4b8c-af07-5051ac168a5a" />

